### PR TITLE
Fix nmap parameter parsing

### DIFF
--- a/services/scanner.py
+++ b/services/scanner.py
@@ -88,16 +88,32 @@ class NmapTarayici:
         # Varsayılan argümanları al
         args = Ayarlar.NMAP_ARGUMANLARI.split()
         
-        # Yeni parametreleri ekle
+        # Yeni parametreleri ekle (bazılarını override et)
         for param, value in nmap_parametreleri.items():
             if value is True:
-                # Değer almayan parametreler (-sS, -sV, -A, vb.)
+                # Değer almayan parametreler (-sS, -sV, -A, -v, -Pn, -n, vb.)
                 if param not in args:
                     args.append(param)
-            else:
-                # Değer alan parametreler (-p, -T, --script, vb.)
-                if param not in args:
-                    args.append(param)
-                    args.append(str(value))
+                continue
+            
+            # Değer alan parametreler (-p, -T, --script, -oN, -oX, -oG, vb.)
+            if param == '-T':
+                # Mevcut -T* tokenlarını kaldır ve -T4 formatında ekle
+                args = [tok for tok in args if not (tok.startswith('-T') and len(tok) >= 2 and tok[2:])]
+                args.append(f"-T{value}")
+                continue
+            if param == '--script':
+                # --script=... biçimini normalize et, varsa eskisini sil
+                args = [tok for tok in args if not tok.startswith('--script')]
+                args.append(f"--script={value}")
+                continue
+            
+            # Diğerleri için çiftli formatı koru
+            if param in args:
+                # Aynı param zaten varsa (örn: -p), mevcut değeri olduğu gibi bırakıp yenisini ekle
+                # Nmap son değeri kullanacaktır
+                pass
+            args.append(param)
+            args.append(str(value))
         
         return ' '.join(args)


### PR DESCRIPTION
Improve Nmap argument parsing to correctly recognize verbose flags (`-v`, `-V`) and handle value-taking parameters.

Previously, common Nmap flags like `-v`/`-V` were not parsed, and value-taking flags (e.g., `-p`, `-T`, `--script`) were incorrectly assigned `True` instead of their actual values, leading to incomplete or incorrect Nmap commands. This PR fixes these parsing issues and updates the help text.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca621127-9694-410e-8009-2bfb70ef1ab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca621127-9694-410e-8009-2bfb70ef1ab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

